### PR TITLE
Link Boost::Python to some and Boost 1.64.0 to all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository provides some instructions on building various external librarie
 #### Requirements:
 ##### Windows:
   Git For Windows SDK - https://github.com/git-for-windows/build-extra/releases
-  Python 2.x - https://www.python.org/downloads/release/python-2711/
+  Python 3.x - https://www.python.org/downloads/release/python-362/
   ActivePerl - http://www.activestate.com/activeperl/downloads
   Ruby - https://www.ruby-lang.org/en/downloads/
   DirectX SDK (for SDL2) - https://www.microsoft.com/en-us/download/details.aspx?id=6812
@@ -13,6 +13,10 @@ This repository provides some instructions on building various external librarie
   If you have problems installing the DirectX SDK, check online. It frequently has issues if you have the visual studio 2010 redistributable installed.
 
   Git For Windows SDK should be installed to C:/git-sdk-64 or vc-bash*.bat files will have to be modified
+
+#### OSX & Linux:
+  (Same purpose but different tools than in Windows)
+  Install build tools: (brew|apt) install git automake libtool autoconf python3@3.6.1
 
 #### Setup Instructions:
   1.Clone this repository

--- a/android/boost.sh
+++ b/android/boost.sh
@@ -2,6 +2,6 @@
 # Boost 1.63
 # ===================
 
-export boost_compiler_patch="s/using [^ ]* ;/using clang : arm : ${CXX//\//\\\/} ;/"
-export boost_additional_args="toolset=clang-arm target-os=linux"
+export boost_compiler_patch="s/using [^ ]* ;/using gcc : arm : $(basename ${CXX}) ;/"
+export boost_additional_args="toolset=gcc-arm target-os=linux"
 source posix/$(basename $0)

--- a/arm-linux/boost.sh
+++ b/arm-linux/boost.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
-# Boost 1.63
-# ===================
+# Boost
+# =====
 
 boost_compiler_patch="s/using gcc ;/using gcc : arm : $(basename ${CXX}) ;/"
 boost_additional_args=toolset="gcc-arm target-os=linux"

--- a/linux/boost.sh
+++ b/linux/boost.sh
@@ -2,6 +2,6 @@
 # Boost 1.63
 # ===================
 
-boost_compiler_patch="s/using gcc ;/using gcc : arm : $(basename ${CXX}) ;/"
+boost_compiler_patch="s/using gcc ;/using gcc : : $(basename ${CXX}) ;/"
 
 source ./posix/$(basename $0)

--- a/linux/boost.sh
+++ b/linux/boost.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
-# Boost 1.63
-# ===================
+# Boost
+# =====
 
 boost_compiler_patch="s/using gcc ;/using gcc : : $(basename ${CXX}) ;/"
 

--- a/mac/boost.sh
+++ b/mac/boost.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
-#!/bin/sh
-# Boost 1.63
-# ===================
+# Boost
+# =====
 
 boost_toolset="--with-toolset=clang"
 source posix/$(basename $0)

--- a/posix/boost.sh
+++ b/posix/boost.sh
@@ -4,7 +4,9 @@
 src_dir=$1
 ins_dir=$2
 
+BREW_PYTHON=$HOME/.linuxbrew/bin/python3
 export PYTHON=python3
+[[ -e "$BREW_PYTHON" ]] && export PYTHON=$BREW_PYTHON
 export PYTHON_VERSION=$($PYTHON -c "import sys; print('{}.{}'.format(*sys.version_info))")
 
 cd src/${src_dir}

--- a/posix/boost.sh
+++ b/posix/boost.sh
@@ -5,22 +5,24 @@
 src_dir=$1
 ins_dir=$2
 
+cd src/${src_dir}
 # Detect Python 3
-brew_python=$home/.linuxbrew/bin/python3
-if   [[ -e "$brew_python" ]];   then PYTHON_EXECUTABLE=$brew_python
+BREW_PYTHON=$HOME/.linuxbrew/bin/python3
+if   [[ -e "$BREW_PYTHON" ]];   then PYTHON_EXECUTABLE=$BREW_PYTHON
 elif [[ -e $(which python3) ]]; then PYTHON_EXECUTABLE=$(which python3)
 fi
+
 if [[ -n "$PYTHON_EXECUTABLE" ]]; then
-  PYTHON_VERSION=$($PYTHON_EXECUTABLE -c "import sys; print('{}.{}'.format(*sys.version_info))" 2>/dev/null)
-  sed -ibak "s,using python.*,using python : $PYTHON_VERSION : $PYTHON_EXECUTABLE
-                                           : $($PYTHON -c 'from __future__ import print_function; import distutils.sysconfig as s; print(s.get_python_inc(True))')
-                                           : $($PYTHON -c 'from __future__ import print_function; import sys; print(sys.prefix)')/lib ;," bootstrap.sh
+  echo "Found $PYTHON_EXECUTABLE. Building Boost::Python (and Boost::Numpy if numpy installed)"
+  export PYTHON_VERSION=$($PYTHON_EXECUTABLE -c "import sys; print('{}.{}'.format(*sys.version_info))" 2>/dev/null)
+  sed -ibak "s,using python.*,using python : $PYTHON_VERSION : $PYTHON_EXECUTABLE \
+                                           : $($PYTHON_EXECUTABLE -c 'from __future__ import print_function; import distutils.sysconfig as s; print(s.get_python_inc(True))')\
+                                           : $($PYTHON_EXECUTABLE -c 'from __future__ import print_function; import sys; print(sys.prefix)')/lib ;," bootstrap.sh
   WITH_PYTHON=--with-python
   PYTHON_VERSION_STRING="python=$PYTHON_VERSION"
+  export PYTHON=$PYTHON_EXECUTABLE
 fi
 # WITH_PYTHON and PYTHON_VERSION_STRING were set if Python 3 was found.
-
-cd src/${src_dir}
 
 rm -fr /tmp/$USER/boost
 

--- a/posix/boost.sh
+++ b/posix/boost.sh
@@ -4,11 +4,15 @@
 src_dir=$1
 ins_dir=$2
 
+export PYTHON=python3
+export PYTHON_VERSION=$($PYTHON -c "import sys; print('{}.{}'.format(*sys.version_info))")
+
 cd src/${src_dir}
 
 rm -fr /tmp/$USER/boost
 
 if [[ ! -x ./b2 ]]; then
+  sed -ibak "s,using python.*,using python : $PYTHON_VERSION : $(which $PYTHON) : $($PYTHON -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_inc(True))') : $($PYTHON -c 'from __future__ import print_function; import sys; print(sys.prefix)')/lib ;," bootstrap.sh
   ./bootstrap.sh ${boost_toolset}
 fi
 
@@ -18,8 +22,6 @@ if [[ -n ${boost_compiler_patch} ]]; then
   sed -i "${boost_compiler_patch}" project-config.jam
 fi
 
-./b2 --prefix="${ins_dir}" --build-dir=/tmp/$USER/ \
---with-atomic --with-chrono --with-date_time --with-filesystem \
---with-locale --with-program_options --with-thread --with-regex \
-link=static threading=multi variant=release ${CFLAGS:+cflags="${CFLAGS}"} \
-${CXXFLAGS:+cxxflags="${CXXFLAGS}"} ${boost_additional_args} install
+./b2 --prefix="${ins_dir}" --build-dir=/tmp/$USER/build-boost python=$PYTHON_VERSION --with-python --with-atomic --with-chrono --with-date_time --with-filesystem \
+     --with-locale --with-program_options --with-thread --with-regex \
+     link=static threading=multi variant=release ${CFLAGS:+cflags="${CFLAGS}"} ${CXXFLAGS:+cxxflags="${CXXFLAGS}"} ${boost_additional_args} install

--- a/posix/boost.sh
+++ b/posix/boost.sh
@@ -6,23 +6,26 @@ src_dir=$1
 ins_dir=$2
 
 cd src/${src_dir}
-# Detect Python 3
-BREW_PYTHON=$HOME/.linuxbrew/bin/python3
-if   [[ -e "$BREW_PYTHON" ]];   then PYTHON_EXECUTABLE=$BREW_PYTHON
-elif [[ -e $(which python3) ]]; then PYTHON_EXECUTABLE=$(which python3)
-fi
 
-if [[ -n "$PYTHON_EXECUTABLE" ]]; then
-  echo "Found $PYTHON_EXECUTABLE. Building Boost::Python (and Boost::Numpy if numpy installed)"
-  export PYTHON_VERSION=$($PYTHON_EXECUTABLE -c "import sys; print('{}.{}'.format(*sys.version_info))" 2>/dev/null)
-  sed -ibak "s,using python.*,using python : $PYTHON_VERSION : $PYTHON_EXECUTABLE \
-                                           : $($PYTHON_EXECUTABLE -c 'from __future__ import print_function; import distutils.sysconfig as s; print(s.get_python_inc(True))')\
-                                           : $($PYTHON_EXECUTABLE -c 'from __future__ import print_function; import sys; print(sys.prefix)')/lib ;," bootstrap.sh
-  WITH_PYTHON=--with-python
-  PYTHON_VERSION_STRING="python=$PYTHON_VERSION"
-  export PYTHON=$PYTHON_EXECUTABLE
+if [[ -z "$SKIP_PYTHON" ]]; then
+  # Detect Python 3
+  BREW_PYTHON=$HOME/.linuxbrew/bin/python3
+  if   [[ -e "$BREW_PYTHON" ]];   then PYTHON_EXECUTABLE=$BREW_PYTHON
+  elif [[ -e $(which python3) ]]; then PYTHON_EXECUTABLE=$(which python3)
+  fi
+
+  if [[ -n "$PYTHON_EXECUTABLE" ]]; then
+    echo "Found $PYTHON_EXECUTABLE. Building Boost::Python (and Boost::Numpy if numpy installed)"
+    export PYTHON_VERSION=$($PYTHON_EXECUTABLE -c "import sys; print('{}.{}'.format(*sys.version_info))" 2>/dev/null)
+    sed -ibak "s,using python.*,using python : $PYTHON_VERSION : $PYTHON_EXECUTABLE \
+                                             : $($PYTHON_EXECUTABLE -c 'from __future__ import print_function; import distutils.sysconfig as s; print(s.get_python_inc(True))')\
+                                             : $($PYTHON_EXECUTABLE -c 'from __future__ import print_function; import sys; print(sys.prefix)')/lib ;," bootstrap.sh
+    WITH_PYTHON=--with-python
+    PYTHON_VERSION_STRING="python=$PYTHON_VERSION"
+    export PYTHON=$PYTHON_EXECUTABLE
+  fi
+  # WITH_PYTHON and PYTHON_VERSION_STRING were set if Python 3 was found.
 fi
-# WITH_PYTHON and PYTHON_VERSION_STRING were set if Python 3 was found.
 
 rm -fr /tmp/$USER/boost
 

--- a/posix/boost.sh
+++ b/posix/boost.sh
@@ -1,20 +1,30 @@
 #!/bin/bash -e
-# Boost 1.63
-# ===================
+# Boost
+# =====
+
 src_dir=$1
 ins_dir=$2
 
-BREW_PYTHON=$HOME/.linuxbrew/bin/python3
-export PYTHON=python3
-[[ -e "$BREW_PYTHON" ]] && export PYTHON=$BREW_PYTHON
-export PYTHON_VERSION=$($PYTHON -c "import sys; print('{}.{}'.format(*sys.version_info))")
+# Detect Python 3
+brew_python=$home/.linuxbrew/bin/python3
+if   [[ -e "$brew_python" ]];   then PYTHON_EXECUTABLE=$brew_python
+elif [[ -e $(which python3) ]]; then PYTHON_EXECUTABLE=$(which python3)
+fi
+if [[ -n "$PYTHON_EXECUTABLE" ]]; then
+  PYTHON_VERSION=$($PYTHON_EXECUTABLE -c "import sys; print('{}.{}'.format(*sys.version_info))" 2>/dev/null)
+  sed -ibak "s,using python.*,using python : $PYTHON_VERSION : $PYTHON_EXECUTABLE
+                                           : $($PYTHON -c 'from __future__ import print_function; import distutils.sysconfig as s; print(s.get_python_inc(True))')
+                                           : $($PYTHON -c 'from __future__ import print_function; import sys; print(sys.prefix)')/lib ;," bootstrap.sh
+  WITH_PYTHON=--with-python
+  PYTHON_VERSION_STRING="python=$PYTHON_VERSION"
+fi
+# WITH_PYTHON and PYTHON_VERSION_STRING were set if Python 3 was found.
 
 cd src/${src_dir}
 
 rm -fr /tmp/$USER/boost
 
 if [[ ! -x ./b2 ]]; then
-  sed -ibak "s,using python.*,using python : $PYTHON_VERSION : $(which $PYTHON) : $($PYTHON -c 'from __future__ import print_function; import distutils.sysconfig; print(distutils.sysconfig.get_python_inc(True))') : $($PYTHON -c 'from __future__ import print_function; import sys; print(sys.prefix)')/lib ;," bootstrap.sh
   ./bootstrap.sh ${boost_toolset}
 fi
 
@@ -24,6 +34,6 @@ if [[ -n ${boost_compiler_patch} ]]; then
   sed -i "${boost_compiler_patch}" project-config.jam
 fi
 
-./b2 --prefix="${ins_dir}" --build-dir=/tmp/$USER/build-boost python=$PYTHON_VERSION --with-python --with-atomic --with-chrono --with-date_time --with-filesystem \
+./b2 --prefix="${ins_dir}" --build-dir=/tmp/$USER/build-boost $PYTHON_VERSION_STRING $WITH_PYTHON --with-atomic --with-chrono --with-date_time --with-filesystem \
      --with-locale --with-program_options --with-thread --with-regex \
      link=static threading=multi variant=release ${CFLAGS:+cflags="${CFLAGS}"} ${CXXFLAGS:+cxxflags="${CXXFLAGS}"} ${boost_additional_args} install

--- a/setup-all-libraries-android32.sh
+++ b/setup-all-libraries-android32.sh
@@ -21,6 +21,7 @@ export LDFLAGS="-static-libstdc++"
 export TOOLCHAIN_FILE=$(pwd)/toolchain-android32.cmake
 export SKIP_QT_BUILD=true
 export SKIP_SWIG_BUILD=true
+export SKIP_PYTHON=true
 
 export CMAKE_ADDITIONAL_ARGS="-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}"
 

--- a/setup-all-libraries-android32.sh
+++ b/setup-all-libraries-android32.sh
@@ -11,9 +11,12 @@ export BUILD_ARCH=x86
 export ARCH_FLAGS=
 
 export HOST=arm-linux-androideabi
+export NDK_TOOLCHAIN=/opt/android-standalone-toolchain
+export CROSS_COMPILER_PATH=${NDK_TOOLCHAIN}/bin
+export PATH=$CROSS_COMPILER_PATH:$PATH
 export CROSS_COMPILER_PREFIX=${HOST}-
-export CC=${NDK_TOOLCHAIN}/bin/clang
-export CXX=${NDK_TOOLCHAIN}/bin/clang++
+export CC=${CROSS_COMPILER_PATH}/${CROSS_COMPILER_PREFIX}gcc
+export CXX=${CROSS_COMPILER_PATH}/${CROSS_COMPILER_PREFIX}g++
 export SYSROOT=${NDK_TOOLCHAIN}/sysroot
 export CFLAGS="-fvisibility=hidden -fvisibility-inlines-hidden"
 export LDFLAGS="-static-libstdc++"

--- a/setup-all-libraries-android64.sh
+++ b/setup-all-libraries-android64.sh
@@ -21,6 +21,7 @@ export LDFLAGS="-static-libstdc++"
 export TOOLCHAIN_FILE=$(pwd)/toolchain-android64.cmake
 export SKIP_QT_BUILD=true
 export SKIP_SWIG_BUILD=true
+export SKIP_PYTHON=true
 
 export CMAKE_ADDITIONAL_ARGS="-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}"
 

--- a/setup-all-libraries-arm-linux-x86.sh
+++ b/setup-all-libraries-arm-linux-x86.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+export EXT_LIB_INSTALL_ROOT="$(cd ..; pwd)/Libraries-arm32"
+source log-output.sh
+
+export BUILD_TYPE=arm-linux
+export BUILD_ARCH=x64
+
+export TOOLCHAIN_PATH=/opt/rk1108_toolchain/usr/bin
+export PATH=$TOOLCHAIN_PATH:$PATH
+export CROSS_COMPILER_PREFIX=$TOOLCHAIN_PATH/arm-rkcvr-linux-uclibcgnueabihf-
+export CROSS_COMPILER_VERSION=4.8.5
+export CC=${CROSS_COMPILER_PREFIX}gcc-${CROSS_COMPILER_VERSION}
+export CXX=${CROSS_COMPILER_PREFIX}g++
+export AR=${CROSS_COMPILER_PREFIX}gcc-ar
+export LD=${CROSS_COMPILER_PREFIX}ld
+export STRIP=${CROSS_COMPILER_PREFIX}strip
+
+source setup-all-libraries-posix.sh

--- a/setup-all-libraries-linux-x64.sh
+++ b/setup-all-libraries-linux-x64.sh
@@ -10,6 +10,10 @@ export CFLAGS="-m64"
 export CXX="g++"
 export CC="gcc"
 
+source setup-library.sh
+setup-library brew://python3 3.6.2 -o "python-3.6.2"
+setup-library pip3://numpy 1.13.1
+
 source setup-all-libraries-posix.sh
 
 #For now, we depend on the jdk being located exactly here

--- a/setup-all-libraries-mac.sh
+++ b/setup-all-libraries-mac.sh
@@ -12,4 +12,8 @@ export CXX=clang++
 export CFLAGS="-mmacosx-version-min=10.10 -arch x86_64"
 export CXXFLAGS="-stdlib=libc++"
 
+source setup-library.sh
+setup-library brew://python3 3.6.2 -o "python-3.6.2"
+setup-library pip3://numpy 1.13.1
+
 source setup-all-libraries-posix.sh

--- a/setup-all-libraries-posix.sh
+++ b/setup-all-libraries-posix.sh
@@ -21,5 +21,5 @@ setup-library http://www.bzip.org/${BZIP2_VERSION}/bzip2-${BZIP2_VERSION}.tar.gz
 setup-library https://github.com/leapmotion/libusb.git 1.0.0 -g -b leap-2.2.x
 setup-library http://sf-github.leap.corp/leapmotion/libuvc.git 1.0.0 -g -b "master"
 
-SWIG_VERSION=3.0.3
+SWIG_VERSION=3.0.12
 setup-library http://iweb.dl.sourceforge.net/project/swig/swig/swig-${SWIG_VERSION}/swig-${SWIG_VERSION}.tar.gz ${SWIG_VERSION} -s "swig-${SWIG_VERSION}" -o "swig-${SWIG_VERSION}" -n "swig"

--- a/setup-all-libraries-posix.sh
+++ b/setup-all-libraries-posix.sh
@@ -12,8 +12,6 @@ source setup-library.sh
 
 #required for bullet
 setup-library http://prdownloads.sourceforge.net/freeglut/freeglut-3.0.0.tar.gz 3.0.0 -s "freeglut-3.0.0" -o "freeglut-3.0.0" -n "freeglut"
-setup-library brew://python3 3.6.2 -o "python-3.6.2"
-setup-library pip3://numpy 1.13.1
 
 source setup-all-libraries.sh
 

--- a/setup-all-libraries-posix.sh
+++ b/setup-all-libraries-posix.sh
@@ -12,6 +12,7 @@ source setup-library.sh
 
 #required for bullet
 setup-library http://prdownloads.sourceforge.net/freeglut/freeglut-3.0.0.tar.gz 3.0.0 -s "freeglut-3.0.0" -o "freeglut-3.0.0" -n "freeglut"
+setup-library brew://python3 3.6.2 -o "python-3.6.2"
 
 source setup-all-libraries.sh
 

--- a/setup-all-libraries-posix.sh
+++ b/setup-all-libraries-posix.sh
@@ -13,6 +13,7 @@ source setup-library.sh
 #required for bullet
 setup-library http://prdownloads.sourceforge.net/freeglut/freeglut-3.0.0.tar.gz 3.0.0 -s "freeglut-3.0.0" -o "freeglut-3.0.0" -n "freeglut"
 setup-library brew://python3 3.6.2 -o "python-3.6.2"
+setup-library pip3://numpy 1.13.1
 
 source setup-all-libraries.sh
 

--- a/setup-all-libraries-win.sh
+++ b/setup-all-libraries-win.sh
@@ -56,7 +56,7 @@ source ./setup-all-libraries.sh
 setup-library https://github.com/dcnieho/FreeGLUT.git 3.0.0 -g -b FG_3_0_0
 setup-library https://github.com/leapmotion/DShowBaseClasses.git 1.0.0 -g -o "baseclasses-1.0.0"
 setup-library http://sf-github.leap.corp/leapmotion/CyAPI.git 1.3.2 -g
-SWIG_VERSION=3.0.3
+SWIG_VERSION=3.0.12
 setup-library http://prdownloads.sourceforge.net/swig/swigwin-${SWIG_VERSION}.zip ${SWIG_VERSION} -s "swigwin-${SWIG_VERSION}" -o "swigwin-${SWIG_VERSION}" -n "swig"
 
 PYTHON_VERSION=2.7.12

--- a/setup-all-libraries-win.sh
+++ b/setup-all-libraries-win.sh
@@ -11,7 +11,7 @@ export BUILD_ARCH=${Platform,,}
 export VS_VER_NUM=${VisualStudioVersion}
 export VS_VER_SHORT=${VS_VER_NUM%\.0}
 VC_VER=${VS_VER_SHORT}
-if [[ "${VC_VER}" == "15" ]; then
+if [[ "${VC_VER}" == "15" ]]; then
   VC_VER=141
 fi
 export VC_VER

--- a/setup-all-libraries.sh
+++ b/setup-all-libraries.sh
@@ -8,7 +8,6 @@ fi
 
 source ./setup-library.sh
 
-setup-library brew://python3 3.6.2 -o "python-3.6.2"
 setup-library http://downloads.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.gz 1.64.0 -s "boost_1_64_0" -o "boost_1_64_0" -n "boost"
 setup-library https://github.com/madler/zlib.git 1.2.8 -g
 setup-library https://github.com/openssl/openssl.git 1.0.2k -g -b "OpenSSL_1_0_2k"

--- a/setup-all-libraries.sh
+++ b/setup-all-libraries.sh
@@ -8,6 +8,7 @@ fi
 
 source ./setup-library.sh
 
+setup-library brew://python3 3.6.2 -o "python-3.6.2"
 setup-library http://downloads.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.gz 1.64.0 -s "boost_1_64_0" -o "boost_1_64_0" -n "boost"
 setup-library https://github.com/madler/zlib.git 1.2.8 -g
 setup-library https://github.com/openssl/openssl.git 1.0.2k -g -b "OpenSSL_1_0_2k"

--- a/setup-all-libraries.sh
+++ b/setup-all-libraries.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [[ ! $EXT_LIB_INSTALL_ROOT ]]; then
   echo "EXT_LIB_INSTALL_ROOT must be defined."

--- a/setup-all-libraries.sh
+++ b/setup-all-libraries.sh
@@ -8,7 +8,7 @@ fi
 
 source ./setup-library.sh
 
-setup-library http://downloads.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.gz 1.64.0 -s "boost_1_64_0" -o "boost_1_64_0" -n "boost"
+setup-library https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.bz2 1.64.0 -s "boost_1_64_0" -o "boost_1_64_0" -n "boost"
 setup-library https://github.com/madler/zlib.git 1.2.8 -g
 setup-library https://github.com/openssl/openssl.git 1.0.2k -g -b "OpenSSL_1_0_2k"
 export OPENSSL_ROOT_DIR=${OPENSSL_PATH}

--- a/setup-library.sh
+++ b/setup-library.sh
@@ -23,7 +23,7 @@ function brew_install {
   [[ -d $BREW_PATH ]] || git clone https://github.com/Linuxbrew/brew $BREW_PATH
   [[ -d $output_dir ]] && echo "$formula already installed." && return
 
-  $BREW_PATH/bin/brew install $formula && cp -r $BREW_PATH/Cellar/python3/$version/ $output_dir
+  $BREW_PATH/bin/brew install $formula && cp -r $BREW_PATH/Cellar/$formula/$version/ $output_dir
 }
 
 function pip3_install {

--- a/setup-library.sh
+++ b/setup-library.sh
@@ -1,3 +1,5 @@
+BREW_PATH=$HOME/.linuxbrew
+
 #!/bin/bash
 function download_git {
   url=$1
@@ -11,6 +13,24 @@ function download_git {
   else
     git clone ${url} --depth 1 ${branch:+--branch ${branch}}
   fi
+}
+
+function brew_install {
+  formula=$1
+  version=$2
+  output_dir=$3
+  # Install/Update Linuxbrew
+  [[ -d $BREW_PATH ]] || git clone https://github.com/Linuxbrew/brew $BREW_PATH
+  [[ -d $output_dir ]] && echo "$formula already installed." && return
+
+  $BREW_PATH/bin/brew install $formula && cp -r $BREW_PATH/Cellar/python3/$version/ $output_dir
+}
+
+function pip3_install {
+  formula=$1
+  version=$2
+
+  $BREW_PATH/bin/pip3 install $formula==$version
 }
 
 function download_curl {
@@ -183,9 +203,19 @@ function setup-library {
     echo force=${force}
   fi
   echo "Building ${base_name}"
-  download_lib ${url} ${branch} ${source_dir} ${force_git}
 
-  build_lib ${source_dir} "${install_root}/${output_dir}" ${base_name}
+  if [[ "${url}" =~ ^brew://.* ]]; then
+    brew_install ${base_name} ${version} "${install_root}/${output_dir}"
+
+  elif [[ "${url}" =~ ^pip3://.* ]]; then
+    pip3_install ${base_name} ${version}
+
+  else
+    download_lib ${url} ${branch} ${source_dir} ${force_git}
+
+    build_lib ${source_dir} "${install_root}/${output_dir}" ${base_name}
+
+  fi
 
   if [[ $OSTYPE == msys* ]]; then
     export ${base_name^^}_PATH="$(cygpath -w ${install_root}/${output_dir})"


### PR DESCRIPTION
Install Boost::Python for the C++ Python bindings.

- [x] Build platform.
- [x] Added two new ways to install packages:
  - [x] `setup-library brew://python3 3.6.2 -o "python-3.6.2"`
  - [x] `setup-library pip3://numpy 1.13.1`