### PR TITLE
Universal builds for swig and libpython3.6 in Mac and simplify python installation process

### DIFF
--- a/posix/boost.sh
+++ b/posix/boost.sh
@@ -9,8 +9,8 @@ cd src/${src_dir}
 
 if [[ -z "$SKIP_PYTHON" ]]; then
   # Detect Python 3
-  BREW_PYTHON=$HOME/.linuxbrew/bin/python3
-  if   [[ -e "$BREW_PYTHON" ]];   then PYTHON_EXECUTABLE=$BREW_PYTHON
+  PYTHON_EXE=$EXT_LIB_INSTALL_ROOT/python-3.5.2/bin/python3
+  if   [[ -e "$PYTHON_EXE" ]];   then PYTHON_EXECUTABLE=$PYTHON_EXE
   elif [[ -e $(which python3) ]]; then PYTHON_EXECUTABLE=$(which python3)
   fi
 

--- a/posix/pyenv.sh
+++ b/posix/pyenv.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+src_dir=$1
+ins_dir=$2
+version=$3
+
+cd src/${src_dir}/plugins/python-build
+
+# Install python builder
+PREFIX=$ins_dir ./install.sh
+
+# Install Python
+PYTHON_CONFIGURE_OPTS="OPT='-fPIC'" $ins_dir/bin/python-build $version $ins_dir
+
+# Install NumPy
+$ins_dir/bin/pip3 install numpy==1.13.1

--- a/setup-all-libraries-linux-x64.sh
+++ b/setup-all-libraries-linux-x64.sh
@@ -11,6 +11,9 @@ export CXX="g++"
 export CC="gcc"
 
 source setup-library.sh
+
+setup-library https://github.com/pyenv/pyenv.git 3.5.2 -g -b master -o python-3.5.2
+
 source setup-all-libraries-posix.sh
 
 #For now, we depend on the jdk being located exactly here

--- a/setup-all-libraries-linux-x64.sh
+++ b/setup-all-libraries-linux-x64.sh
@@ -11,9 +11,6 @@ export CXX="g++"
 export CC="gcc"
 
 source setup-library.sh
-setup-library brew://python3 3.6.2 -o "python-3.6.2"
-setup-library pip3://numpy 1.13.1
-
 source setup-all-libraries-posix.sh
 
 #For now, we depend on the jdk being located exactly here

--- a/setup-all-libraries-mac.sh
+++ b/setup-all-libraries-mac.sh
@@ -13,7 +13,4 @@ export CFLAGS="-mmacosx-version-min=10.10 -arch i386 -arch x86_64"
 export CXXFLAGS="-stdlib=libc++"
 
 source setup-library.sh
-setup-library brew://sashkab/python/python36 3.6.2 -o "python-3.6.2"
-setup-library pip3://numpy 1.13.1
-
 source setup-all-libraries-posix.sh

--- a/setup-all-libraries-mac.sh
+++ b/setup-all-libraries-mac.sh
@@ -13,4 +13,7 @@ export CFLAGS="-mmacosx-version-min=10.10 -arch i386 -arch x86_64"
 export CXXFLAGS="-stdlib=libc++"
 
 source setup-library.sh
+
+setup-library https://github.com/pyenv/pyenv.git 3.5.2 -g -b master -o python-3.5.2
+
 source setup-all-libraries-posix.sh

--- a/setup-all-libraries-mac.sh
+++ b/setup-all-libraries-mac.sh
@@ -9,7 +9,7 @@ export MACOSX_DEPLOYMENT_TARGET=10.10
 export CMAKE_ADDITIONAL_ARGS="-DCMAKE_OSX_ARCHITECTURES:STRING=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.10 -DCMAKE_OSX_SYSROOT=macosx10.12"
 export CC=clang
 export CXX=clang++
-export CFLAGS="-mmacosx-version-min=10.10 -arch x86_64"
+export CFLAGS="-mmacosx-version-min=10.10 -arch i386 -arch x86_64"
 export CXXFLAGS="-stdlib=libc++"
 
 source setup-library.sh

--- a/setup-all-libraries-mac.sh
+++ b/setup-all-libraries-mac.sh
@@ -13,7 +13,7 @@ export CFLAGS="-mmacosx-version-min=10.10 -arch i386 -arch x86_64"
 export CXXFLAGS="-stdlib=libc++"
 
 source setup-library.sh
-setup-library brew://python3 3.6.2 -o "python-3.6.2"
+setup-library brew://sashkab/python/python36 3.6.2 -o "python-3.6.2"
 setup-library pip3://numpy 1.13.1
 
 source setup-all-libraries-posix.sh

--- a/setup-bash-x86-vc12.bat
+++ b/setup-bash-x86-vc12.bat
@@ -1,0 +1,4 @@
+@echo off
+echo Loading VC...
+call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
+"C:\Program Files\Git\bin\bash.exe" --login -i

--- a/setup-library.sh
+++ b/setup-library.sh
@@ -97,15 +97,16 @@ function build_lib {
   source_dir=$1
   install_path=$2
   base_name=$3
+  version=$4
   if [[ ! -d "${install_path}" ]] || [[ ${force} == true ]]; then
     if [[ ${BUILD_TYPE} == win ]]; then
       install_path=$(cygpath -w $2)
     fi
 
     if [[ ! -f "./${BUILD_TYPE}/${base_name}.sh" ]]; then
-      ./posix/${base_name}.sh ${source_dir} ${install_path}
+      ./posix/${base_name}.sh ${source_dir} ${install_path} ${version}
     else
-      ./${BUILD_TYPE}/${base_name}.sh ${source_dir} ${install_path}
+      ./${BUILD_TYPE}/${base_name}.sh ${source_dir} ${install_path} ${version}
     fi
   fi
 }
@@ -200,7 +201,7 @@ function setup-library {
 
   download_lib ${url} ${branch} ${source_dir} ${force_git}
 
-  build_lib ${source_dir} "${install_root}/${output_dir}" ${base_name}
+  build_lib "${source_dir}" "${install_root}/${output_dir}" "${base_name}" "${version}"
 
 
   if [[ $OSTYPE == msys* ]]; then

--- a/setup-library.sh
+++ b/setup-library.sh
@@ -1,6 +1,7 @@
+#!/bin/bash
+
 BREW_PATH=$HOME/.linuxbrew
 
-#!/bin/bash
 function download_git {
   url=$1
   branch=$2
@@ -216,7 +217,7 @@ function setup-library {
   echo "Building ${base_name}"
 
   if [[ "${url}" =~ ^brew://.* ]]; then
-    brew_install ${base_name} ${version} "${install_root}/${output_dir}"
+    brew_install ${url##*//} ${version} "${install_root}/${output_dir}"
 
   elif [[ "${url}" =~ ^pip3://.* ]]; then
     pip3_install ${base_name} ${version}

--- a/setup-library.sh
+++ b/setup-library.sh
@@ -24,7 +24,7 @@ function brew_install {
   [[ -d $BREW_PATH ]] || git clone https://github.com/Linuxbrew/brew $BREW_PATH
   [[ -d $output_dir ]] && echo "$formula already installed." && return
 
-  $BREW_PATH/bin/brew install $formula && cp -r $BREW_PATH/Cellar/$formula/$version/ $output_dir
+  $BREW_PATH/bin/brew install $formula && cp -rL $BREW_PATH/Cellar/$formula/$version/ $output_dir
 }
 
 function pip3_install {

--- a/setup-library.sh
+++ b/setup-library.sh
@@ -16,24 +16,6 @@ function download_git {
   fi
 }
 
-function brew_install {
-  formula=$1
-  version=$2
-  output_dir=$3
-  # Install/Update Linuxbrew
-  [[ -d $BREW_PATH ]] || git clone https://github.com/Linuxbrew/brew $BREW_PATH
-  [[ -d $output_dir ]] && echo "$formula already installed." && return
-
-  $BREW_PATH/bin/brew install $formula && cp -rL $BREW_PATH/Cellar/$formula/$version/ $output_dir
-}
-
-function pip3_install {
-  formula=$1
-  version=$2
-
-  $BREW_PATH/bin/pip3 install $formula==$version
-}
-
 function download_curl {
   url=$1
   filename=$(basename ${url})
@@ -216,18 +198,10 @@ function setup-library {
   fi
   echo "Building ${base_name}"
 
-  if [[ "${url}" =~ ^brew://.* ]]; then
-    brew_install ${url##*//} ${version} "${install_root}/${output_dir}"
+  download_lib ${url} ${branch} ${source_dir} ${force_git}
 
-  elif [[ "${url}" =~ ^pip3://.* ]]; then
-    pip3_install ${base_name} ${version}
+  build_lib ${source_dir} "${install_root}/${output_dir}" ${base_name}
 
-  else
-    download_lib ${url} ${branch} ${source_dir} ${force_git}
-
-    build_lib ${source_dir} "${install_root}/${output_dir}" ${base_name}
-
-  fi
 
   if [[ $OSTYPE == msys* ]]; then
     export ${base_name^^}_PATH="$(cygpath -w ${install_root}/${output_dir})"

--- a/setup-library.sh
+++ b/setup-library.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-BREW_PATH=$HOME/.linuxbrew
-
 function download_git {
   url=$1
   branch=$2


### PR DESCRIPTION
Have universal 32/64 swig-3.0.12 and libpython3.6.

- [x] Tested mac builds for python and swig in build servers
- [x] Test linux python.