### PR TITLE
Fix missing realpath command

### DIFF
--- a/setup-library.sh
+++ b/setup-library.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# realpath is not available on macOS
+which realpath || realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
 if [[ -z "${BUILD_DIR}" ]]; then
   export BUILD_DIR=$(realpath ./src)
 fi


### PR DESCRIPTION
Just tried to build a library on macOS and ran into several errors. It appears we recently added a dependency on `realpath`, which is available on Linux and msysgit, but not Mac.