### PR TITLE
Fix flatbuffers android

### DIFF
--- a/android/flatbuffers.patch
+++ b/android/flatbuffers.patch
@@ -1,0 +1,50 @@
+commit 234cd8ce9cc29e8d64aeadab697469c8266f193c
+Author: Walter Gray <wgray@leapmotion.com>
+Date:   Thu Mar 8 18:56:36 2018 -0800
+
+    test
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5599fda..c8518e4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,7 +47,7 @@ set(FlatBuffers_Compiler_SRCS
+   src/idl_gen_cpp.cpp
+   src/idl_gen_general.cpp
+   src/idl_gen_go.cpp
+-  src/idl_gen_js.cpp
++  #src/idl_gen_js.cpp
+   src/idl_gen_php.cpp
+   src/idl_gen_python.cpp
+   src/idl_gen_fbs.cpp
+diff --git a/src/flatc_main.cpp b/src/flatc_main.cpp
+index 02d01c0..cbd51f6 100644
+--- a/src/flatc_main.cpp
++++ b/src/flatc_main.cpp
+@@ -71,16 +71,16 @@ int main(int argc, const char *argv[]) {
+       flatbuffers::IDLOptions::kJava,
+       "Generate Java classes for tables/structs",
+       flatbuffers::GeneralMakeRule },
+-    { flatbuffers::GenerateJS,       "-s", "--js", "JavaScript", true,
+-      nullptr,
+-      flatbuffers::IDLOptions::kJs,
+-      "Generate JavaScript code for tables/structs",
+-      flatbuffers::JSMakeRule },
+-    { flatbuffers::GenerateJS,       "-T", "--ts", "TypeScript", true,
+-      nullptr,
+-      flatbuffers::IDLOptions::kTs,
+-      "Generate TypeScript code for tables/structs",
+-      flatbuffers::JSMakeRule },
++//    { flatbuffers::GenerateJS,       "-s", "--js", "JavaScript", true,
++//      nullptr,
++//      flatbuffers::IDLOptions::kJs,
++//      "Generate JavaScript code for tables/structs",
++//      flatbuffers::JSMakeRule },
++//    { flatbuffers::GenerateJS,       "-T", "--ts", "TypeScript", true,
++//      nullptr,
++//      flatbuffers::IDLOptions::kTs,
++//      "Generate TypeScript code for tables/structs",
++//      flatbuffers::JSMakeRule },
+     { flatbuffers::GenerateGeneral,  "-n", "--csharp", "C#", true,
+       nullptr,
+       flatbuffers::IDLOptions::kCSharp,

--- a/android/flatbuffers.sh
+++ b/android/flatbuffers.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+git apply --directory="$(realpath --relative-to=. src/$1)" android/flatbuffers.patch
+source posix/$(basename $0)

--- a/posix/flatbuffers.sh
+++ b/posix/flatbuffers.sh
@@ -6,4 +6,4 @@ src_dir=$1
 ins_dir=$2
 cd ${BUILD_DIR}/${src_dir}
 
-build_cmake_lib "${ins_dir}" -DFLATBUFFERS_BUILD_TESTS:BOOL=OFF
+build_cmake_lib "${ins_dir}" -DFLATBUFFERS_BUILD_TESTS:BOOL=OFF -DCMAKE_CXX_STANDARD:STRING=11


### PR DESCRIPTION
disables the javascript schema generation since it depends on std::to_string which isn't supported by the version of android we use currently.