### PR TITLE
fix arm-linux flatbuffers build

### DIFF
--- a/arm-linux/flatbuffers.sh
+++ b/arm-linux/flatbuffers.sh
@@ -5,5 +5,5 @@
 #typelimits error found in gcc5 with FB 1.0 - upgrading the library may resolve
 export CXXFLAGS="${CXXFLAGS} -Wno-type-limits"
 export PATH=${PATH}:. #only required in gcc5? what?
-export CMAKE_ADDITIONAL_ARGS="${CMAKE_ADDITIONAL_ARGS} -DHAVE_X11_EXTENSIONS_XF86VMODE_H:BOOL=OFF -DX11_xf86vmode_FOUND:BOOL=OFF"
+export CMAKE_ADDITIONAL_ARGS="${CMAKE_ADDITIONAL_ARGS} -DCMAKE_CXX_STANDARD:STRING=11"
 source posix/$(basename $0)

--- a/setup-all-libraries-arm-linux-x64.sh
+++ b/setup-all-libraries-arm-linux-x64.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-export EXT_LIB_INSTALL_ROOT="/opt/local/Libraries-arm64"
+export EXT_LIB_INSTALL_ROOT="$(cd ..; pwd)/Libraries-arm64"
+
 source log-output.sh
 
 export BUILD_TYPE=arm-linux


### PR DESCRIPTION
disables the javascript schema generation since it depends on std::to_string which isn't supported by the version of android we use currently.