### PR TITLE
Fix AntTweakBar build

### DIFF
--- a/posix/anttweakbar.sh
+++ b/posix/anttweakbar.sh
@@ -6,7 +6,7 @@ src_dir=$1
 ins_dir=$2
 cd ${BUILD_DIR}/${src_dir}
 
-cd ${BUILD_DIR}
+cd src
 CXXCFG="-O3"
 if [ ${BUILD_TYPE} != "mac" ]; then
   CXXCFG="${CXXCFG} -fpermissive"


### PR DESCRIPTION
This appears to have been broken in fdccbce4e.

`make` needs to be called from `src/anttweakbar/src`, but that line was going to the top-level `src`